### PR TITLE
libcommhistory offset vs limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.deb
+*.log
+*.o
+
+src/smsbackuprestore
+src/moc_catcher.cpp
+
+Makefile
+build-stamp
+configure-stamp
+
+debian/smsbackuprestore/
+debian/files
+debian/smsbackuprestore.aegis
+debian/smsbackuprestore.substvars

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+dir=$(dirname `readlink -f $0`)
+project=$(basename "$dir")
+debname="smsbackuprestore"
+mnt=/scratchbox/users/$USER/home/$USER/$project
+
+if ! mount | grep "$project on $mnt"; then
+  sudo /scratchbox/sbin/sbox_ctl start
+  sudo /scratchbox/sbin/sbox_sync
+
+  mkdir -p $mnt
+  sudo mount -o bind $dir $mnt
+fi
+
+
+/scratchbox/login -d $HOME find -maxdepth 2 -name $debname*.deb -delete
+/scratchbox/login -d $HOME find -maxdepth 2 -name $debname*.changes -delete
+/scratchbox/login -d $HOME find -maxdepth 2 -name $debname*.dsc -delete
+/scratchbox/login -d $HOME find -maxdepth 2 -name $debname*.gz -delete
+
+/scratchbox/login -d $HOME/$project qmake
+/scratchbox/login -d $HOME/$project dpkg-buildpackage
+
+deb=`/scratchbox/login -d $HOME find -maxdepth 1 -name $debname*.deb`
+echo copying $deb from sbox $HOME to $HOME/$project
+/scratchbox/login -d $HOME cp $deb $HOME/$project

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -132,8 +132,8 @@ void Util::exportSMS(QTextStream &out) {
             count = model.rowCount();
             offset += count;
 
-            // If we got less than limit events, then it's the last batch
-            keepgoing = (count == limit);
+            // Stop when no more events found
+            keepgoing = (count > 0);
 
             // the events got by getEvents is reversed-ordered
             for (int i = count - 1; i >= 0; i--) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -130,7 +130,7 @@ void Util::exportSMS(QTextStream &out) {
             model.getEvents(g.id());
             std::cout << "  got " << model.rowCount() << " events for group " << g.id() << std::endl;
             count = model.rowCount();
-            offset += count;
+            offset += limit;
 
             // Stop when no more events found
             keepgoing = (count > 0);


### PR DESCRIPTION
libcommhistory is a jumbled mess. because of the way it calculates offset/limit, it appears that tying offset to rowcount is actually more dangerous than tying offset to limit.
